### PR TITLE
Update Bootstrap theme variables

### DIFF
--- a/scss/_variables-dark.scss
+++ b/scss/_variables-dark.scss
@@ -26,7 +26,7 @@ $info-bg-subtle-dark:               shade-color($info, 80%) !default;
 $warning-bg-subtle-dark:            shade-color($warning, 80%) !default;
 $danger-bg-subtle-dark:             shade-color($danger, 80%) !default;
 $light-bg-subtle-dark:              $gray-800 !default;
-$dark-bg-subtle-dark:               mix($gray-800, $black) !default;
+$dark-bg-subtle-dark:               mix($primary, $black) !default;
 // scss-docs-end theme-bg-subtle-dark-variables
 
 // scss-docs-start theme-border-subtle-dark-variables
@@ -41,14 +41,14 @@ $dark-border-subtle-dark:           $gray-800 !default;
 // scss-docs-end theme-border-subtle-dark-variables
 
 $body-color-dark:                   $gray-300 !default;
-$body-bg-dark:                      $gray-900 !default;
+$body-bg-dark:                      $primary !default;
 $body-secondary-color-dark:         rgba($body-color-dark, .75) !default;
 $body-secondary-bg-dark:            $gray-800 !default;
 $body-tertiary-color-dark:          rgba($body-color-dark, .5) !default;
 $body-tertiary-bg-dark:             mix($gray-800, $gray-900, 50%) !default;
 $body-emphasis-color-dark:          $white !default;
-$border-color-dark:                 $gray-700 !default;
-$border-color-translucent-dark:     rgba($white, .15) !default;
+$border-color-dark:                 tint-color($primary, 20%) !default;
+$border-color-translucent-dark:     rgba($primary, .15) !default;
 $headings-color-dark:               inherit !default;
 $link-color-dark:                   tint-color($primary, 40%) !default;
 $link-hover-color-dark:             shift-color($link-color-dark, -$link-shade-percentage) !default;

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -36,7 +36,7 @@ $grays: (
 // fusv-enable
 
 // scss-docs-start color-variables
-$blue:    #0d6efd !default;
+$blue:    #09093c !default;
 $indigo:  #6610f2 !default;
 $purple:  #6f42c1 !default;
 $pink:    #d63384 !default;
@@ -299,7 +299,7 @@ $cyans: (
 
 // scss-docs-start theme-color-variables
 $primary:       $blue !default;
-$secondary:     $gray-600 !default;
+$secondary:     #9e0106 !default;
 $success:       $green !default;
 $info:          $cyan !default;
 $warning:       $yellow !default;
@@ -539,8 +539,8 @@ $border-widths: (
   5: 5px
 ) !default;
 $border-style:                solid !default;
-$border-color:                $gray-300 !default;
-$border-color-translucent:    rgba($black, .175) !default;
+$border-color:                tint-color($primary, 70%) !default;
+$border-color-translucent:    rgba($primary, .175) !default;
 // scss-docs-end border-variables
 
 // scss-docs-start border-radius-variables
@@ -556,10 +556,10 @@ $border-radius-2xl:           $border-radius-xxl !default; // Deprecated in v5.3
 // fusv-enable
 
 // scss-docs-start box-shadow-variables
-$box-shadow:                  0 .5rem 1rem rgba($black, .15) !default;
-$box-shadow-sm:               0 .125rem .25rem rgba($black, .075) !default;
-$box-shadow-lg:               0 1rem 3rem rgba($black, .175) !default;
-$box-shadow-inset:            inset 0 1px 2px rgba($black, .075) !default;
+$box-shadow:                  0 .5rem 1rem rgba($primary, .15) !default;
+$box-shadow-sm:               0 .125rem .25rem rgba($primary, .075) !default;
+$box-shadow-lg:               0 1rem 3rem rgba($primary, .175) !default;
+$box-shadow-inset:            inset 0 1px 2px rgba($primary, .075) !default;
 // scss-docs-end box-shadow-variables
 
 $component-active-color:      $white !default;


### PR DESCRIPTION
## Summary
- change base `$blue` to dark navy and use as brand primary
- set brand red `$secondary`
- apply primary color to border and shadow defaults
- adapt dark mode variables for new brand colors

## Testing
- `npm run test` *(fails: Server start failed on port 9876: Error: Please install Chrome, Chromium or Firefox)*

------
https://chatgpt.com/codex/tasks/task_e_6873a15e89c083298c440958794f1234